### PR TITLE
Fix dependent compilation when it's triggered by stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/*.js
 tests/*.html
 tests/*.js
 tests/*/*.js
+.stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-06-10
+resolver: lts-12.7
 packages:
 - .
 - fay-base


### PR DESCRIPTION
## Problem statement

- Stack used in project
- Project triggered Fay programmatically.
- I want to add new fay package in dependency list.
- During compilation stack used its own ghc and ghc-pkg.
- Stack rewrites HASKELL_SANDBOX_CONFIG, GHC_PACKAGE_PATH environment variables.
- Fay cannot find new package.

## Impact analysis

- Since project compilation constantly failed I am loosing ability to ship new versions into production.
- This is not a blocker since I can reimplement package functionality in my project.

## Solution Proposal

- Proposed simple analysis for ghc and ghc-pkg from ghc-paths:
- If their paths contained ".stack" inside then:
  - stack exec -- ghc # for ghc
  - stack exec -- ghc-pkg # for ghc-pkg
- otherwise fallback to previous execution flow.